### PR TITLE
Change the block element from table to div to allow smaller blocks

### DIFF
--- a/MMM-Block.css
+++ b/MMM-Block.css
@@ -1,0 +1,3 @@
+.MMM-Block module-header {
+  height: 0;
+}

--- a/MMM-Block.css
+++ b/MMM-Block.css
@@ -1,3 +1,3 @@
-.MMM-Block module-header {
-  height: 0;
+.MMM-Block {
+  margin-top: 0 !important;
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -12,7 +12,6 @@ Module.register("MMM-Block", {
   // Override dom generator.
   getDom: function() {
 	var wrapper = document.createElement("div");
-    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
     wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0'></div>";
     return wrapper;
   }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -13,7 +13,7 @@ Module.register("MMM-Block", {
   getDom: function() {
 	var wrapper = document.createElement("div");
     //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; background-color: #98FFFF'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -13,7 +13,7 @@ Module.register("MMM-Block", {
   getDom: function() {
 	var wrapper = document.createElement("div");
     //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; background-color: #98FFFF'></div>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; width=10px; background-color: #98FFFF'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -12,7 +12,8 @@ Module.register("MMM-Block", {
   // Override dom generator.
   getDom: function() {
 	var wrapper = document.createElement("div");
-    wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
+    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -13,7 +13,7 @@ Module.register("MMM-Block", {
   getDom: function() {
 	var wrapper = document.createElement("div");
     //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0; background-color: #333'></div>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -12,7 +12,7 @@ Module.register("MMM-Block", {
   // Override dom generator.
   getDom: function() {
 	var wrapper = document.createElement("div");
-    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
+    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px; background-color: #333'><td style='text-align:center'>&nbsp;</td></tr></table>";
     wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
     return wrapper;
   }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -6,14 +6,18 @@
 
 Module.register("MMM-Block", {
 // Module config defaults.
-  defaults: {
-	  height: 600,
-  },
-  // Override dom generator.
-  getDom: function() {
-	var wrapper = document.createElement("div");
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0'></div>";
-    return wrapper;
-  }
+	defaults: {
+		height: 600,
+	},
+// Add CSS.
+	getStyles: function() {
+		return ["MMM-Block.css"];
+	},
+// Override dom generator.
+	getDom: function() {
+		var wrapper = document.createElement("div");
+		wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0'></div>";
+		return wrapper;
+	}
 }
 );

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -13,7 +13,7 @@ Module.register("MMM-Block", {
   getDom: function() {
 	var wrapper = document.createElement("div");
     //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; width=10px; background-color: #98FFFF'></div>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -13,7 +13,7 @@ Module.register("MMM-Block", {
   getDom: function() {
 	var wrapper = document.createElement("div");
     //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; background-color: #333'></div>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0; background-color: #333'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -12,8 +12,8 @@ Module.register("MMM-Block", {
   // Override dom generator.
   getDom: function() {
 	var wrapper = document.createElement("div");
-    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px; background-color: #333'><td style='text-align:center'>&nbsp;</td></tr></table>";
-    wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
+    //wrapper.innerHTML = "<table border=0 style='table-layout:fixed width=301px'><tr style='height:" + this.config.height + "px'><td style='text-align:center'>&nbsp;</td></tr></table>";
+    wrapper.innerHTML = "<div style='height:" + this.config.height + "px; background-color: #333'></div>";
     return wrapper;
   }
 }

--- a/MMM-Block.js
+++ b/MMM-Block.js
@@ -16,7 +16,7 @@ Module.register("MMM-Block", {
 // Override dom generator.
 	getDom: function() {
 		var wrapper = document.createElement("div");
-		wrapper.innerHTML = "<div style='height:" + this.config.height + "px; padding: 0'></div>";
+		wrapper.innerHTML = "<div style='height:" + this.config.height + "px'></div>";
 		return wrapper;
 	}
 }


### PR DESCRIPTION
This is a quasi-breaking change in that it will change the actual height of elements with the same config files, so I understand if you do not want to merge it.  But I think it's an improvement.  

The current module inserts a `<table>` cell, which has some built-in padding and/or spacing by default.  So even when the module height is set to 0px, there will still be _some_ height to the new element.  Changing the element to a `<div>` either minimizes or eliminates the padding so that users can create much smaller blocks.